### PR TITLE
fix: verbose call method is broken

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -38,6 +38,11 @@ export class Client {
 	}
 
 	async call (method, ...args) {
+		if (typeof(method) === 'object') {
+			let verbose = method;
+			method = verbose['method'];
+			args = verbose['params'];
+		}
 		if (!method || typeof method !== 'string') {
 			throw new Error('method parameter is required');
 		}

--- a/test/src/Client.js
+++ b/test/src/Client.js
@@ -175,7 +175,45 @@ describe('Client', () => {
 			await server.close();
 		});
 
-		it('should support synchronous server methods returning boolean false', async () => {
+		it('should support calling via object verbose syntax', async () => {
+			let
+				client = new Client(mockPath),
+				server = new Server(mockPath, mockServices);
+
+			await server.listen();
+
+			let result = await client.call({
+				id      : Date.now(),
+				jsonrpc : '2.0',
+				method  : 'd.falsePromise',
+				params  : []
+			});
+
+			should.exist(result);
+			result.should.equal(false);
+			await server.close();
+		});
+
+        it('should accept arguments also in verbose syntax', async () => {
+			let
+				client = new Client(mockPath),
+				server = new Server(mockPath, mockServices);
+
+			await server.listen();
+
+			let result = await client.call({
+				id      : Date.now(),
+				jsonrpc : '2.0',
+				method  : 'b.lowerCasePromise',
+				params  : ['TESTING']
+			});
+
+			should.exist(result);
+			result.should.equal('testing');
+			await server.close();
+		});
+
+        it('should support synchronous server methods returning boolean false', async () => {
 			let
 				client = new Client(mockPath),
 				server = new Server(mockPath, mockServices);


### PR DESCRIPTION
The verbose call feature seems broken as the Client will always raise `method parameter is required`. This RP creates the missing testcases that for now fail by intention.

Note: The verbose syntax is introduced on the projects main README.md and the feature is just not working