### PR TITLE
fix: prevent request being serialized twice

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -67,11 +67,9 @@ export class Client {
 				// connect to the Unix domain socket and transmit the request
 				let socket = net.createConnection(self.path, () => {
 					if (socket.writable) {
-						debug(
-							'Client: writing message to socket connection: %o',
-							request);
-
-						socket.write(JSON.stringify(request));
+						if (typeof(request) === 'object') request = JSON.stringify(request);
+						debug('Client: writing message to socket connection: %o', request);
+						socket.write(request);
 					}
 				});
 


### PR DESCRIPTION
json-ipc-lib will make use of json-rpc-protocol module.
In its current form it already does a JSON.stringify inside the submodule.
Client.js tries this a second time, which will result in
a compliant server not understand the request.

{ Error: JSON-IPC Client Exception::Expected {} for json command
    at Socket.<anonymous> (./node_modules/json-ipc-lib/dist/Client.js:171:36)
    at Socket.emit (events.js:197:13)

Note:
This will not happen for 'method only' calls but for
'object' {method, params, ...} calls.

Relevant code snippets:

Client.js
```JS
import * as protocol from 'json-rpc-protocol';
// ...
protocol.format.request(
	Date.now(),
	method,
	args);
...
socket.write(JSON.strinify(request));
```

node_modules/json-rpc-protocol/dist/format.js
```JS
var toJson = JSON.stringify;
...
  return toJson({
    jsonrpc: '2.0',
    id,
    error: _error
  });
```